### PR TITLE
Fixed incorrect old changelog's description

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -140,7 +140,7 @@
   * Bug fixed in Exception text when field names was not matching the database
   * Bug fixed so Realm no longer throws an Exception when removing the last object
   * Bug fixed in RealmResults which prevented sub-querying
-  * The Date type does not support millisecond resolution, and dates before 1900-12-13
+  * The Date type does not support millisecond resolution, and dates before 1901-12-13
     and dates after 2038-01-19 are not supported on 32 bit systems
   * Fixed bug so Realm no longer throws an Exception when removing the last object
   * Bug fixed in RealmResults which prevented subquerying


### PR DESCRIPTION
`setDate` will check range of date object as Integer.
http://www.epochconverter.com/

So, the lower bound is -2147483648 and will convert "Fri, 13 Dec 1901 20:45:52 GMT".
http://www.epochconverter.com/
